### PR TITLE
Add missing steps for github token

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ Install:
 
 Run:
 
-`work-stats --username=bob --email=bob@gmail.com,bob@golang.org --since=2019-01-01`
+Grab a token from https://github.com/settings/tokens. It will need: `read:discussion, read:enterprise, read:gpg_key, read:org, read:packages, read:public_key, read:repo_hook, repo, user`.
+
+```
+export GITHUB_TOKEN=<your token>
+work-stats --username=bob --email=bob@gmail.com,bob@golang.org --since=2019-01-01
+```
 
 ### TODO
 * Automatically generate Google Sheets


### PR DESCRIPTION
The token probably needs less permissions than that, but I was too lazy to figure out which it minimally needs.