### PR TITLE
do not automatically attempt to create Google Sheets output

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,20 @@ $ work-stats --email=bob@gmail.com,bob@golang.org --since=2019-01-01
 ```
 
 ### Other GitHub contributions
-Grab a token from https://github.com/settings/tokens. It will need: `read:discussion, read:enterprise, read:gpg_key, read:org, read:packages, read:public_key, read:repo_hook, repo, user`. You will also need to pass in your GitHub username.
+
+Grab a token from https://github.com/settings/tokens. It will need: 
+
+```
+read:discussion
+read:enterprise
+read:gpg_key
+read:org
+read:packages
+read:public_key
+read:repo_hook
+repo
+user
+```
 
 ```shell
 $ export GITHUB_TOKEN=<your token>
@@ -33,14 +46,36 @@ $ work-stats --username=bob --email=bob@gmail.com,bob@golang.org --since=2019-01
 
 ### Export data to Google Sheets
 
-This is a bit more involved, but the output will be a formatted Google sheet with different tabs for each category. To use the Google Sheets API from a command-line tool, you will need to create a Google Cloud project with the Google Sheets API enabled. The easiest way to do this is by following the link on the [Google Sheets API tutorial](https://developers.google.com/sheets/api/quickstart/go). It will create a project with the name "Quickstart". It will prompt you to download a `credentials.json` file. The path to that file will need to be passed in through the `-credentials` flag. These credentials will be used to generate a token the first time you run the program. Pass the file path at which you would like the token to be created through the  `-token` flag.
+This is a bit more involved, but the output will be a formatted Google sheet
+\with different tabs for each category. To use the Google Sheets API from a
+command-line tool, you will need to create a Google Cloud project with the
+Google Sheets API enabled. The easiest way to do this is by following the link
+on the [Google Sheets API tutorial](https://developers.google.com/sheets/api/quickstart/go).
+It will create a project with the name "Quickstart". It will prompt you to
+download a `credentials.json` file. The path to that file will need to be passed
+in through the `-credentials` flag. These credentials will be used to generate a
+token the first time you run the program. Pass the file path at which you would
+like the token to be created through the  `-token` flag.
 
-Alternatively, if you do not follow the Quickstart link, you can go to https://pantheon.corp.google.com/apis and create a new project with any name. Click on "Enable APIs", select the Google Sheets API, and clicking "Enable". Then click "APIs & Services" -> "Credentials" -> "Create Credentials" -> "Oauth client ID". Once the credentials are created, click the download button on the right. The path to the credentials will be passed through the `-credentials` flag. These credentials will be used to generate a token the first time you run the program. Pass the file path at which you would like the token to be created through the  `-token` flag.
+Alternatively, if you do not follow the Quickstart link, you can go to
+https://pantheon.corp.google.com/apis and create a new project with any name.
+Click on "Enable APIs", select the Google Sheets API, and clicking "Enable".
+Then click "APIs & Services" -> "Credentials" -> "Create Credentials" ->
+"Oauth client ID". Once the credentials are created, click the download button
+on the right. The path to the credentials will be passed through the
+`-credentials` flag. These credentials will be used to generate a token the
+first time you run the program. Pass the file path at which you would like the
+token to be created through the  `-token` flag.
 
 The command will then be:
 
 ```shell
-$ work-stats --username=bob --email=bob@gmail.com,bob@golang.org --since=2019-01-01 --sheets=true --credentials=/path/to/credentials.json --token=/path/to/token.json
+$ work-stats --username=bob \
+    --email=bob@gmail.com,bob@golang.org \
+    --since=2019-01-01 \
+    --sheets=true \
+    --credentials=/path/to/credentials.json \
+    --token=/path/to/token.json
 ```
 
 Make sure to add `-sheets` to turn on the Google Sheets feature. When you first create the token, you will be prompted to authorize your Google Clould project to access your Google account by following a link. The link to your Google sheet will be printed when the program exits.

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -169,6 +170,7 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfru
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=


### PR DESCRIPTION
This commit cleans up a usability issue: that when you provide only your
    github/gerrit credentials, this program fails because it tries to create google
    sheets stuff (which is guaranteed to fail, since it hasn't been provided). It
    fixes this by setting the default value of the sheets flag to empty, which
    causes the program to exit before it tries to create sheets unless the user
    specifically sets that flag.

Several examples on the README.md are therefore fixed with this.

It also fixes the problem a second time by setting tokenFile and credentialsFile
to default empty values, and adding a check that they actually got set by the
user before attempting to spin up a google sheet. In addition to fixing the
aforementioned problem (again), they are a little better user experience: users
won't get cryptic "file not found credentials.json" errors and have no idea what
is credentials.json.

Also cleans up:

- README.md 80 char limit
- README.md use multi-line code snippets for wide snippets
- Refactor google sheets ID parsing into its own function
- Use log.Print* everywhere rather than a mix of log.Print* and fmt.Print*